### PR TITLE
bump ecctl to 1.7

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -935,8 +935,8 @@ contents:
             prefix:     en/ecctl
             tags:       CloudControl/Reference
             subject:    ECCTL
-            current:    1.6
-            branches:   [ master, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            current:    1.7
+            branches:   [ master, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
this adjusts the docs to the 1.7 branch of ecctl that was created back
in december. 

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->